### PR TITLE
feat: add dedicated 404 page with themed UI and home redirect

### DIFF
--- a/frontend/src/components/NotFound.tsx
+++ b/frontend/src/components/NotFound.tsx
@@ -1,12 +1,31 @@
-"use client"
+"use client";
 
-import React from 'react';
+import React from "react";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
 
-
-const NotFound = () => {
+export default function NotFound() {
   return (
-    <div>not found go to home</div>
+    <main className="min-h-screen flex items-center justify-center bg-black px-6">
+      <div className="text-center">
+        <h1 className="text-7xl sm:text-8xl font-bold text-emerald-500">404</h1>
+        <h2 className="mt-6 text-3xl sm:text-4xl font-semibold text-white">
+          Page Not Found
+        </h2>
+        <p className="mt-4 text-lg text-gray-400 max-w-md mx-auto">
+          The page you are looking for does not exist or has been moved.
+        </p>
+
+        <div className="mt-10">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-6 py-3 text-sm font-semibold text-black hover:bg-emerald-400 transition duration-300"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Go to Home
+          </Link>
+        </div>
+      </div>
+    </main>
   );
 }
-
-export default NotFound


### PR DESCRIPTION
Fixes #35 

This PR introduces a dedicated 404 – Page Not Found page to improve user experience when navigating to invalid or non-existent routes

<img width="2218" height="1124" alt="image" src="https://github.com/user-attachments/assets/b3137972-419d-4dad-97af-b694a66d877c" />
