### PR TITLE
Payment page

### DIFF
--- a/frontend/src/app/payment/page.tsx
+++ b/frontend/src/app/payment/page.tsx
@@ -92,13 +92,18 @@ export default function Payment  (){
         amount: orderData.data.amount,
         user_email: session?.user?.email, 
       });
-      // Show success state and redirect after a short delay
-      setPaymentSuccess(true);
-      setTimeout(() => {
-        router.push("/");
-      }, 3000);
+      if (resp.data?.success) {
+        // Show success state and redirect after a short delay
+        setPaymentSuccess(true);
+        setTimeout(() => {
+          router.push("/");
+        }, 3000);
+      } else {
+        alert(resp.data?.message || "Payment verification failed. Please contact support.");
+      }
     } catch (error) {
       console.error("Error storing payment:", error);
+      alert("Payment verification failed. Please try again or contact support.");
     }
       },
       prefill: {


### PR DESCRIPTION
Description:

What changed
- After a successful payment, users now see a "Your Payment is Successful!" confirmation screen and are automatically redirected to the homepage after 3 seconds.
- If a user is already on the Pro plan and navigates to /payment, they see "You already have an active Subscription" instead of the payment form.
- Added backend response validation — the success screen only appears when the server confirms the payment was verified.
- Users now see an error alert if payment verification fails, instead of a silent failure.
Why
- Previously there was no feedback after payment and no guard against pro users re-purchasing. These changes improve UX and prevent unnecessary transactions.

How to test
- Pro user flow: Log in as a pro user → navigate to /payment → should see the active subscription message.
- Payment flow: Log in as a free user → navigate to /payment → complete a test payment → should see success message → auto-redirect to homepage.
- Failure flow: If verification fails (e.g., invalid signature), an error alert should appear.